### PR TITLE
add github link and HF link to index

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,10 @@ This task addresses the nuanced challenge of identifying item relationships, suc
 Details are in the [recommendation task instructions](recommendations.md)
 
 ## Instructions and Datasets
-Detailed instructions and datasets will be released soon. Please subscribe and wait.
+Detailed instructions will be released soon. Please subscribe and wait.
+
+For code see our github repo here: <a href="https://huggingface.co/trec-product-search">Github Repo</a>
+For datasets see our Huggingface repo here: <a href="https://huggingface.co/trec-product-search">Huggingface Repo</a>
 
 ## Submission, Evaluation, and Judging
 


### PR DESCRIPTION
This PR adds the links to our Github and HF repos. They are added under the "Instructions and Datasets" section. 