### PR TITLE
Update deadline to Sept 14th

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,8 +16,8 @@ Online shopping has drastically reshaped consumer expectations, emphasizing spee
 
 ## Important Dates
 
-- **Data release:** TBD  
-- **Submission period:** TBD  
+- **Data release:** August 25th
+- **Submission deadline:** September 14th  
 - **Conference:** November 18th @ Gaithersburg, MD  
 
 ## Subscribe for Track Updates

--- a/recommendations.md
+++ b/recommendations.md
@@ -168,4 +168,4 @@ We will compute supplementary metrics including:
 * Task Data Release: **Now available**
 * Development Period: Summer 2025
 * Test Query Release: **Aug. 25, 2025**
-* Submission Deadline: **Sep. 4, 2025**
+* Submission Deadline: **September 14th**

--- a/search.md
+++ b/search.md
@@ -91,10 +91,10 @@ The primary evaluation metrics will be:
 For the Interactive Reformulation track, the best-performing reformulated query (according to the Task Completion NDCG) will be used for the final evaluation.
 
 ## Timeline
-- Task Data Release: May 27, 2025
+- Task Data Release: May 27th
 - Development Period: Summer 2025
-- Test Query Release: Late August 2025
-- Submission Deadline: Early September 2025
+- Test Query Release: August 25th
+- Submission Deadline: September 14th
 
 ## Repos
 For code see our github repo here: <a href="https://github.com/inertia-lab/trec-product-search-recs/tree/main/search-task-2025">Github Repo</a>


### PR DESCRIPTION
This PR updates some of the deadlines to sept 14 on the index, search, and recommendation page. It also removes some of the outdated "TBD" dates. 